### PR TITLE
Cache domain parsing results

### DIFF
--- a/scripts/readdocuments.py
+++ b/scripts/readdocuments.py
@@ -65,7 +65,9 @@ def main():
         
         
     langident = heli_otr.Identifier()
-    ds = docscorer.DocumentScorer()     
+    ds = docscorer.DocumentScorer()
+
+    domain_cache = {}
     
     for json_line in args.input:
         doc = json.loads(json_line)         
@@ -140,10 +142,15 @@ def main():
         url = doc.get(url_field)
         try:
             fulldomain = urlparse(url).netloc #This includes subdomain
-            rawdomain = tldextract.extract(fulldomain).domain #This does not include subdomain
-            tld = tldextract.extract(fulldomain).suffix #This is the TDL removing the preceeding dot
-            domain = rawdomain+"."+tld
-        except Exception as ex:            
+            if fulldomain in domain_cache:
+                domain, tld = domain_cache[fulldomain]
+            else:
+                extract_res = tldextract.extract(fulldomain)
+                rawdomain = extract_res.domain #This does not include subdomain
+                tld = extract_res.suffix #This is the TDL removing the preceeding dot
+                domain = rawdomain + "." + tld
+                domain_cache[fulldomain] = (domain, tld)
+        except Exception as ex:
             logging.error("Bad url: " + url)
             logging.error(ex)
 


### PR DESCRIPTION
## Summary
- add a `domain_cache` dictionary to store extracted domain information
- reuse cached values so `tldextract.extract` is called once per domain

## Testing
- `python3 -m py_compile scripts/readdocuments.py`

------
https://chatgpt.com/codex/tasks/task_e_688729fe35fc8323b8258aa8a1545f28