### PR TITLE
Add duplication ratio stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The stats generated with this tool come in a handy yaml format with the followin
 - `trg_top100_tld`: 100 most common top level domains in target segments (not including subdomains), and the amount of segments for each one (only for HPLT parallel corpora)
 - `trg_unique_sents`: Distribution of target segments having a certain amount of tokens, after removing duplicated segments (only for parallel corpora)
 - `unique_sents`: Total amount of segments (for monolingual corpora) or segment pairs (for parallel corpora), after removing duplicated segments or segment pairs
+- `duplication_ratio`: Portion of segments that were identified as duplicates, computed as duplicates divided by total segments
 - `sample`: JSON array with up to 50 example documents, segments or segment pairs from the corpus
 - `warnings`: List of issues encountered while processing the corpus.
   - `src_warning_tok_xxx_yyy`: The source language is not supported by a dedicated tokenizer, so it fallbacks to the xxx tokenizer with the yyy language (only for parallel corpora).

--- a/front/src/components/Report.js
+++ b/front/src/components/Report.js
@@ -129,6 +129,7 @@ export default function Report({ date, report }) {
     : "";
 
   const uniqueSegments = report.unique_sents ? report.unique_sents : "";
+  const duplicationRatio = report.duplication_ratio ?? "";
 
   const srcTokens = numberFormatter(src_tokens) ?? "";
 
@@ -235,6 +236,9 @@ export default function Report({ date, report }) {
                       {!trglang && uniqueSegments && (
                         <th className={styles.desktopData}>Unique segments</th>
                       )}
+                      {duplicationRatio !== "" && (
+                        <th className={styles.desktopData}>Duplication ratio</th>
+                      )}
                       {!trglang && srcTokens && (
                         <th className={styles.desktopData}>
                           <div className={styles.containsTooltip}>
@@ -322,6 +326,11 @@ export default function Report({ date, report }) {
                           </p>
                         </td>
                       )}
+                      {duplicationRatio !== "" && (
+                        <td className={styles.desktopData}>
+                          {(duplicationRatio * 100).toFixed(2)}%
+                        </td>
+                      )}
                       {srcTokens && (
                         <td className={styles.desktopData}>{srcTokens}</td>
                       )}
@@ -377,6 +386,11 @@ export default function Report({ date, report }) {
                           %)
                         </span>
                       )}
+                    </p>
+                  )}
+                  {duplicationRatio !== "" && (
+                    <p className={styles.mobileNum}>
+                      Duplication ratio - {(duplicationRatio * 100).toFixed(2)}%
                     </p>
                   )}
                   {!trglang && srcTokens && <p>Tokens - {srcTokens}</p>}

--- a/scripts/reduce/write_volumes.py
+++ b/scripts/reduce/write_volumes.py
@@ -31,7 +31,9 @@ def main():
         stats["trg_chars"] = int(volumes[6])
         stats["src_pii"] = int(volumes[7])
         stats["trg_pii"] = int(volumes[8])
-        stats["unique_sents"] = int(volumes[9])-1  #Removing one because of empty fields in the proc file due to ngrams
+        stats["unique_sents"] = int(volumes[9]) - 1  # Removing one because of empty fields in the proc file due to ngrams
+        duplicates = stats["sentence_pairs"] - stats["unique_sents"]
+        stats["duplication_ratio"] = round(duplicates / stats["sentence_pairs"], 4)
     if len(volumes) == 6: 
         #is mono
         #0: sentences 1:srctokcount 2:srcbytes 3:srcchars 4:srcpii 5:uniquesents
@@ -40,7 +42,9 @@ def main():
         stats["src_bytes"] = int(volumes[2])
         stats["src_chars"] = int(volumes[3])
         stats["src_pii"] = int(volumes[4])
-        stats["unique_sents"] = int(volumes[5])-1
+        stats["unique_sents"] = int(volumes[5]) - 1
+        duplicates = stats["sentence_pairs"] - stats["unique_sents"]
+        stats["duplication_ratio"] = round(duplicates / stats["sentence_pairs"], 4)
     yaml.dump(stats, args.yamlfile)
             
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- compute duplication_ratio in `write_volumes.py`
- document duplication_ratio field
- display duplication ratio in the frontend report

## Testing
- `pytest -q`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68872f5cb9d48323af99d8f97c766814