### PR TITLE
Lazy import tokenizer modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you need to access docker to run stuff inside:
 * sudo docker exec -it dat-webapp /bin/bash
 
 Code and data are located in `/work`. Yaml files served in the frontend must be placed in `/work/yaml_dir/`. In order to check that everything is working seamlessly, there are some tests scripts located in `/work/tests/` that you can run.
+Only the tokenizers for the languages you process need to be installed. See [tokenizers-info.md](tokenizers-info.md) for details.
 
 ## Generating stats
 

--- a/tokenizers-info.md
+++ b/tokenizers-info.md
@@ -1,5 +1,8 @@
 Tokenizers used for each language:
 
+Only the tokenizers required for the languages you analyze must be installed.
+If a tokenizer is missing, the tool falls back to NLTK's `WordPunctTokenizer` and records a warning.
+
 * as, ca, cs, co, de, el, en, es, fi, fr, ga, hu, is, it, lt, lv, mni, nl, pl, pt, ro, ru, sk, sl, sv, ta: sacremoses (MosesTokenizer) (https://github.com/hplt-project/sacremoses)
 * da, et, no, tr: NLTK word tokenizer (https://www.nltk.org/api/nltk.tokenize.html)
 * sr, mk, bg, hr: Reldi (https://github.com/clarinsi/reldi-tokeniser)


### PR DESCRIPTION
## Summary
- lazily import tokenizer modules using `importlib` inside `CustomTokenizer.setTokenizer`
- add fallback handling when a module is missing
- mention selective tokenizer installation in docs

## Testing
- `python3 -m py_compile scripts/tokenizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b781c9ec8323866a737c9f8a0b84