### PR TITLE
Wrap DomainLabels chart for PDF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ HPLTAnalytics comes with a webapp that is able to display the generated yaml fil
     - Percentage of segments in the declared languge, inside documents (only for monolingual documents)
 - Document Score distribution: Histogram showing the distribution of Document Score (only for monolingual documents)
 - Segment length distribution: Histogram showing the distribution of tokens per segment in source (monolingual) or source and target (parallel), showing total, unique and duplicate segments or segment pairs
-- Noise distribution: the result of applying hard rules and computing which percentage is affected by them (too short or too long sentences, sentences being URLs, bad encoding, sentences containing poor language, etc.). 
+- Noise distribution: the result of applying hard rules and computing which percentage is affected by them (too short or too long sentences, sentences being URLs, bad encoding, sentences containing poor language, etc.).
 - Frequent n-grams: 1-5 more frequent n-grams
+
+### Exporting the report to PDF
+
+Use the **Export to PDF** button at the bottom of the viewer to generate a PDF containing all charts displayed on the page, including register and domain labels when available.
 
 We also display samples for some of the datasets. These are currently obtained out of the HPLTAnalytics tool and all the storage and the logic of which sample/labels must be displayed is currently happening in Javascript. Further versions of HPLTAnalytics will properly handle this.
 

--- a/front/src/components/Report.js
+++ b/front/src/components/Report.js
@@ -438,7 +438,9 @@ export default function Report({ date, report }) {
         />
       )}
       {report["domain_labels"] && (
-        <DomainLabels labels={report["domain_labels"]} />
+        <div className="custom-chart">
+          <DomainLabels labels={report["domain_labels"]} />
+        </div>
       )}
       {report.docs_segments && (
         <div className="custom-chart">


### PR DESCRIPTION
## Summary
- Wrap DomainLabels component in a `custom-chart` div so PDF exports capture it.
- Document how to export reports to PDF in README.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bddb00348323b6d5c529ea4656ca